### PR TITLE
Fix spelling in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Metasploitable 2 VAPT Report
 
 This repository contains a comprehensive penetration testing report on **Metasploitable 2**, a vulnerable virtual machine
-designed for training , practise and testing .The machine is Linux based and contains several outdated services and misconfigurations.
+designed for training , practice and testing .The machine is Linux based and contains several outdated services and misconfigurations.
 
 ## Test Outcomes
 Metasploitable 2 presents a high-risk attack surface with major critical vulnerabilities that allowed complete root access to the  systems .


### PR DESCRIPTION
## Summary
- fix a misspelling in the Readme introduction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842afda02188325b4382193eff286f5